### PR TITLE
Add GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+        env:
+          BASE_PATH: "/${{ github.event.repository.name }}/"
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: gh-pages
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "test": "playwright test"
+    "test": "playwright test",
+    "postinstall": "playwright install --with-deps"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const basePath = process.env.BASE_PATH ?? '/'
+
 export default defineConfig({
+  base: basePath,
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build and deploy the Vite project to `gh-pages`
- make base path configurable via `BASE_PATH` environment variable for GitHub Pages
- automatically install Playwright browsers so tests run without manual setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860466a87ec832fb2e5307f3d72299a