### PR TITLE
Add UI flow tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+test-results

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ src/
 playwright.config.ts
 tests/
 .github/workflows/deploy.yml
+test-results/

--- a/src/DeadwoodGame.tsx
+++ b/src/DeadwoodGame.tsx
@@ -144,6 +144,14 @@ const DeadwoodGame: React.FC = () => {
   }
   const [gameState, dispatch] = useReducer(gameReducer, initialState)
 
+  // expose helpers for Playwright tests
+  useEffect(() => {
+    ;(window as any).dispatchGameAction = dispatch
+    ;(window as any).getGameState = () => gameState
+    ;(window as any).GamePhase = GamePhase
+    ;(window as any).ActionType = ActionType
+  }, [dispatch, gameState])
+
   useEffect(() => {
     if (gameState.phase === GamePhase.PLAYER_TURN && gameState.players[gameState.currentPlayer]?.isAI && !gameState.pendingAction && gameState.completedActions.length === 0) {
       const timer = setTimeout(() => {

--- a/tests/ui_flow.spec.ts
+++ b/tests/ui_flow.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test'
+
+const locations = ['Gem Saloon', 'Hardware Store', 'Bella Union', 'Sheriff Office', 'Freight Office', "Wu's Pig Alley"]
+
+async function startGame(page) {
+  await page.addInitScript(() => {
+    Math.random = () => 0.1
+  })
+  await page.goto('/')
+  await page.getByRole('button', { name: 'Start Game' }).click()
+  await expect(page.locator('text=Turn 1')).toBeVisible()
+}
+
+function getCurrentPlayerInfo(page) {
+  return page.locator('div').filter({ hasText: 'Gold:' }).locator('..')
+}
+
+async function getInfluence(page) {
+  const text = await page.getByText('Influence:', { exact: false }).locator('strong').textContent()
+  return parseInt(text || '0', 10)
+}
+
+test('starting the game with default options', async ({ page }) => {
+  await page.addInitScript(() => {
+    Math.random = () => 0.1
+  })
+  await page.goto('/')
+  await expect(page.getByRole('heading', { name: 'Deadwood Showdown' })).toBeVisible()
+  const selects = page.locator('select')
+  await expect(selects.nth(0)).toHaveValue('2')
+  await expect(selects.nth(1)).toHaveValue('medium')
+  await page.getByRole('button', { name: 'Start Game' }).click()
+  await expect(page.locator('text=Turn 1')).toBeVisible()
+})
+
+test('moving to another location and claiming influence', async ({ page }) => {
+  await startGame(page)
+  await page.getByRole('button', { name: /Move/ }).click()
+  for (const name of locations) {
+    await page.getByRole('heading', { name }).click()
+    const confirm = page.getByRole('button', { name: /Confirm MOVE/i })
+    if (await confirm.isEnabled()) {
+      await confirm.click()
+      break
+    }
+  }
+  await page.getByRole('button', { name: /Claim/ }).click()
+  await page.getByRole('button', { name: /Confirm CLAIM/i }).click()
+  await expect.poll(() => getInfluence(page)).toBeGreaterThan(0)
+})
+
+test('resting adds gold', async ({ page }) => {
+  await startGame(page)
+  const info = getCurrentPlayerInfo(page)
+  const initialGold = parseInt(await info.getByText(/Gold:/).locator('strong').textContent() || '0', 10)
+  await page.getByRole('button', { name: /Rest/ }).click()
+  const goldAfter = parseInt(await info.getByText(/Gold:/).locator('strong').textContent() || '0', 10)
+  expect(goldAfter).toBe(initialGold + 2)
+})
+

--- a/tests/ui_ux_tests.feature
+++ b/tests/ui_ux_tests.feature
@@ -1,0 +1,62 @@
+Feature: Deadwood Showdown UI/UX test plan
+  # This feature file documents high level scenarios to cover the game's
+  # critical user flows. It is meant as guidance for writing Playwright
+  # tests. Each scenario describes expected behaviour and suggests stable
+  # selectors to avoid flaky tests.
+
+  Background:
+    Given the application is started
+    And the page has loaded
+
+  Scenario: Starting the game with default options
+    When the user views the setup screen
+    Then the title "Deadwood Showdown" is visible
+    And the player count selector defaults to "2 Players"
+    And the AI difficulty selector defaults to "Medium"
+    When the user clicks the "Start Game" button
+    Then the game board should appear
+    And the turn message should contain "Turn 1"
+
+  Scenario: Moving to another location and claiming influence
+    Given a deterministic starting state for easy assertions
+    When the user selects the "Move" action
+    Then all reachable locations should highlight as valid targets
+    When the user clicks a highlighted location and confirms
+    Then the player's position and gold should update accordingly
+    And the turn message should prompt for the final action
+    When the user selects "Claim" and chooses amount "1" gold
+    And confirms the claim action
+    Then the current location should show the player with one influence star
+    And the player's gold total should decrease by one
+    And the turn should advance to the next player
+
+  Scenario: Challenging an opponent
+    Given the opponent has at least one influence star at the same location
+    When the user selects the "Challenge" action
+    Then the opponent should highlight as a valid target
+    When the user confirms the challenge
+    Then the opponent's influence is reduced by one
+    And the user's gold decreases by the correct challenge cost
+    And the turn message should update appropriately
+
+  Scenario: Resting for gold
+    When the user selects "Rest"
+    Then two gold are immediately added to the player's total
+    And the turn message prompts for the final action
+
+  Scenario: Disabled actions when not allowed
+    Given the current location is at max influence for the player
+    Then the "Claim" button should be disabled
+    Given the player lacks enough gold or targets
+    Then the "Challenge" button should be disabled
+
+  Scenario: Automatic AI turn after the player completes two actions
+    When the human player finishes their second action
+    Then the next player (AI) should begin their turn automatically
+    And the board should update once the AI completes its actions
+
+  Scenario: Victory and starting a new game
+    Given a victory condition is met
+    Then a "Game Over" screen should display the winner and final scores
+    When the user clicks "New Game"
+    Then the setup screen should appear again


### PR DESCRIPTION
## Summary
- expose game state helpers for Playwright
- add Playwright tests covering basic game flow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68604bdcac04832fb8194117a36dc73a