### PR TITLE
Add additional unit tests for game logic

### DIFF
--- a/tests/unit/abilities.test.ts
+++ b/tests/unit/abilities.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { executeAction } from '../../src/game/reducer'
+import { ActionType, GamePhase, type GameState } from '../../src/game/types'
+import { CHARACTERS } from '../../src/game/players'
+import { createInitialBoard } from '../../src/game/board'
+
+const makePlayer = (charIndex: number, position: number) => ({
+  id: `p${charIndex}`,
+  name: `P${charIndex}`,
+  character: CHARACTERS[charIndex],
+  position,
+  gold: 3,
+  totalInfluence: 0,
+  isAI: false,
+  actionsRemaining: 2,
+})
+
+describe('character abilities', () => {
+  it("Al Swearengen gains gold when players enter Gem Saloon", () => {
+    const state: GameState = {
+      phase: GamePhase.PLAYER_TURN,
+      currentPlayer: 1,
+      players: [makePlayer(0, 1), makePlayer(1, 2)],
+      board: createInitialBoard(),
+      turnCount: 1,
+      gameConfig: { playerCount: 2, aiDifficulty: 'easy' },
+      actionHistory: [],
+      completedActions: [],
+      pendingAction: undefined,
+      message: '',
+    }
+    const newState = executeAction(state, { type: ActionType.MOVE, target: 0 })
+    expect(newState.players[0].gold).toBe(4)
+    expect(newState.players[1].position).toBe(0)
+    expect(newState.players[1].gold).toBe(2)
+  })
+})

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { getMoveCost, getChallengeCost, canChallenge } from '../../src/game/utils'
+import { CHARACTERS } from '../../src/game/players'
+
+const makePlayer = (characterIndex: number, position = 0) => ({
+  id: `p${characterIndex}`,
+  name: `P${characterIndex}`,
+  character: CHARACTERS[characterIndex],
+  position,
+  gold: 3,
+  totalInfluence: 0,
+  isAI: false,
+  actionsRemaining: 2,
+})
+
+describe('utils', () => {
+  it('calculates move cost including Calamity Jane ability', () => {
+    const normal = makePlayer(0, 0) // Al Swearengen
+    const jane = makePlayer(3, 0) // Calamity Jane
+    expect(getMoveCost(normal, 0, 1)).toBe(0)
+    expect(getMoveCost(normal, 0, 2)).toBe(1)
+    expect(getMoveCost(jane, 0, 5)).toBe(0)
+  })
+
+  it('calculates challenge cost including Seth Bullock ability', () => {
+    const seth = makePlayer(1)
+    const al = makePlayer(0)
+    expect(getChallengeCost(seth)).toBe(1)
+    expect(getChallengeCost(al)).toBe(2)
+  })
+
+  it('determines valid challenge targets with Cy Tolliver ability', () => {
+    const cy = makePlayer(2, 0)
+    const targetAdjacent = makePlayer(1, 1)
+    const normal = makePlayer(0, 0)
+    expect(canChallenge(cy, targetAdjacent)).toBe(true)
+    expect(canChallenge(normal, targetAdjacent)).toBe(false)
+  })
+})

--- a/tests/unit/victory.test.ts
+++ b/tests/unit/victory.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { checkVictoryConditions } from '../../src/game/reducer'
+import { GamePhase, type GameState } from '../../src/game/types'
+import { CHARACTERS } from '../../src/game/players'
+import { createInitialBoard } from '../../src/game/board'
+
+const makePlayer = (charIndex: number) => ({
+  id: `p${charIndex}`,
+  name: `P${charIndex}`,
+  character: CHARACTERS[charIndex],
+  position: 0,
+  gold: 3,
+  totalInfluence: 0,
+  isAI: false,
+  actionsRemaining: 2,
+})
+
+describe('victory conditions', () => {
+  it('detects total influence victory', () => {
+    const state: GameState = {
+      phase: GamePhase.PLAYER_TURN,
+      currentPlayer: 0,
+      players: [makePlayer(0), makePlayer(1)],
+      board: createInitialBoard(),
+      turnCount: 1,
+      gameConfig: { playerCount: 2, aiDifficulty: 'easy' },
+      actionHistory: [],
+      completedActions: [],
+      pendingAction: undefined,
+      message: '',
+    }
+    state.players[0].totalInfluence = 12
+    expect(checkVictoryConditions(state)).toBe(0)
+  })
+
+  it('detects location control victory', () => {
+    const board = createInitialBoard()
+    board[0].influences['p0'] = 3
+    board[1].influences['p0'] = 3
+    board[2].influences['p0'] = 3
+    const state: GameState = {
+      phase: GamePhase.PLAYER_TURN,
+      currentPlayer: 0,
+      players: [makePlayer(0), makePlayer(1)],
+      board,
+      turnCount: 1,
+      gameConfig: { playerCount: 2, aiDifficulty: 'easy' },
+      actionHistory: [],
+      completedActions: [],
+      pendingAction: undefined,
+      message: '',
+    }
+    state.players[0].totalInfluence = 9
+    expect(checkVictoryConditions(state)).toBe(0)
+  })
+
+  it('uses gold as tiebreaker at turn limit', () => {
+    const state: GameState = {
+      phase: GamePhase.PLAYER_TURN,
+      currentPlayer: 0,
+      players: [makePlayer(0), makePlayer(1)],
+      board: createInitialBoard(),
+      turnCount: 20,
+      gameConfig: { playerCount: 2, aiDifficulty: 'easy' },
+      actionHistory: [],
+      completedActions: [],
+      pendingAction: undefined,
+      message: '',
+    }
+    state.players[0].totalInfluence = 5
+    state.players[1].totalInfluence = 5
+    state.players[0].gold = 3
+    state.players[1].gold = 6
+    expect(checkVictoryConditions(state)).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- add utils tests for move, challenge, and Cy Tolliver ability
- test Al Swearengen gold ability on move into Gem Saloon
- cover victory condition logic including tiebreakers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68605d6b6724832fa387be60e69970be