### PR TITLE
Fix CI Node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
       - run: npm ci
       - run: npm run lint

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
       - run: npm ci
       - run: npm run build

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ The game ends immediately when a player achieves either:
 
 ### Prerequisites
 
-- Node.js 14+ and npm/yarn
+- Node.js 20+ and npm/yarn
 - Basic knowledge of React development
 
 ### Quick Start

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "lint": "prettier --check .",
     "format": "prettier --write ."
   },
+  "engines": {
+    "node": ">=20"
+  },
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
## Summary
- use Node 20 in GitHub workflows for compatibility with Vite
- document Node 20 requirement
- enforce Node 20 via `engines`

## Testing
- `npm ci`
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68606591b318832f9c90d5e14336237c