### PR TITLE
Fix Rest action completing turns

### DIFF
--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -152,16 +152,42 @@ const gameReducer = (state: GameState, action: GameAction): GameState => {
       const currentPlayer = state.players[state.currentPlayer]
       if (actionType === ActionType.REST) {
         const newState = executeAction(state, { type: ActionType.REST })
+        const newCompleted = [
+          ...state.completedActions,
+          { type: ActionType.REST },
+        ]
+
+        if (newCompleted.length >= 2) {
+          const winner = checkVictoryConditions(newState)
+          if (winner !== undefined) {
+            return {
+              ...newState,
+              phase: GamePhase.GAME_OVER,
+              winner,
+              completedActions: newCompleted,
+              pendingAction: undefined,
+              message: `${newState.players[winner].name} wins!`,
+            }
+          }
+          const nextPlayer = (state.currentPlayer + 1) % state.players.length
+          const isNewRound = nextPlayer === 0
+          return {
+            ...newState,
+            currentPlayer: nextPlayer,
+            turnCount: isNewRound ? state.turnCount + 1 : state.turnCount,
+            completedActions: [],
+            pendingAction: undefined,
+            message:
+              `Turn ${isNewRound ? state.turnCount + 1 : state.turnCount} • ` +
+              `${newState.players[nextPlayer].character.name}'s turn`,
+          }
+        }
+
         return {
           ...newState,
-          completedActions: [
-            ...state.completedActions,
-            { type: ActionType.REST },
-          ],
-          message:
-            state.completedActions.length === 0
-              ? 'Select your final action'
-              : 'Turn complete!',
+          completedActions: newCompleted,
+          pendingAction: undefined,
+          message: 'Select your final action',
         }
       }
       if (actionType === ActionType.CLAIM) {

--- a/tests/unit/rest_turn.test.ts
+++ b/tests/unit/rest_turn.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { gameReducer } from '../../src/game'
+import { createInitialBoard } from '../../src/game'
+import { createPlayers } from '../../src/game/players'
+import { GamePhase, ActionType, type GameState } from '../../src/game'
+
+const initialState: GameState = {
+  phase: GamePhase.PLAYER_TURN,
+  currentPlayer: 0,
+  players: createPlayers(2),
+  board: createInitialBoard(),
+  turnCount: 1,
+  gameConfig: { playerCount: 2, aiDifficulty: 'easy' },
+  actionHistory: [],
+  completedActions: [],
+  pendingAction: undefined,
+  message: '',
+}
+
+describe('rest action turn flow', () => {
+  it('double rest ends the turn and passes control', () => {
+    let state = gameReducer(initialState, { type: 'SELECT_ACTION', payload: ActionType.REST })
+    state = gameReducer(state, { type: 'SELECT_ACTION', payload: ActionType.REST })
+    expect(state.completedActions).toHaveLength(0)
+    expect(state.currentPlayer).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- ensure double Rest ends the player turn
- add unit test covering Rest twice scenario

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68606e7db3a4832f94dbb14236051e5c