### PR TITLE
Bug 6: claim amount validation gap fix

### DIFF
--- a/docs/task-update.md
+++ b/docs/task-update.md
@@ -11,3 +11,10 @@
 - Updated cancel action to clear challenge target list
 - What's next: review remaining bug fixes
 
+### [2025-06-28 23:46 UTC] Claim amount validation fix
+
+- Implemented robust backend claim validation
+- Improved dropdown options and added UI feedback
+- Updated action availability logic
+- Added comprehensive unit and e2e tests
+- What's next: ensure all tests pass and finalize PR

--- a/src/DeadwoodGame.tsx
+++ b/src/DeadwoodGame.tsx
@@ -147,6 +147,29 @@ const DeadwoodGame: React.FC = () => {
     }
   }
 
+  const getClaimValidation = () => {
+    if (gameState.pendingAction?.type !== ActionType.CLAIM) return null
+
+    const amount = gameState.pendingAction.amount || 1
+    const currentPlayer = gameState.players[gameState.currentPlayer]
+    const location = gameState.board[currentPlayer.position]
+    const currentInf = getLocationInfluence(location, currentPlayer.id)
+    const maxSpace = location.maxInfluence - currentInf
+    const maxAffordable = currentPlayer.gold
+
+    if (amount > maxAffordable) {
+      return { valid: false, message: 'Not enough gold' }
+    }
+    if (amount > maxSpace) {
+      return { valid: false, message: 'Not enough space at location' }
+    }
+    if (maxSpace === 0) {
+      return { valid: false, message: 'Location is full' }
+    }
+
+    return { valid: true, message: null }
+  }
+
   const getValidChallengeTargets = (): string[] => {
     if (gameState.pendingAction?.type !== ActionType.CHALLENGE) return []
     const currentPlayer = gameState.players[gameState.currentPlayer]
@@ -172,9 +195,10 @@ const DeadwoodGame: React.FC = () => {
           location,
           currentPlayer.id
         )
-        return (
-          currentPlayer.gold >= 1 && currentInfluence < location.maxInfluence
-        )
+        const hasSpace = currentInfluence < location.maxInfluence
+        const hasGold = currentPlayer.gold >= 1
+
+        return hasSpace && hasGold
       }
       case ActionType.CHALLENGE: {
         const cost = getChallengeCost(currentPlayer)
@@ -458,19 +482,49 @@ const DeadwoodGame: React.FC = () => {
                         currentPlayer.id
                       )
                       const maxSpace = location.maxInfluence - currentInf
-                      const maxClaim = Math.min(currentPlayer.gold, maxSpace)
-                      if (amt > maxClaim) return null
-                      const isValid = amt <= maxClaim
+                      const maxAffordable = currentPlayer.gold
+                      const maxClaim = Math.min(maxAffordable, maxSpace)
+
+                      if (amt > maxClaim) {
+                        return (
+                          <option
+                            key={amt}
+                            value={amt}
+                            disabled={true}
+                            style={{ color: '#999' }}
+                          >
+                            {amt} Gold (Not available)
+                          </option>
+                        )
+                      }
+
                       return (
-                        <option key={amt} value={amt} disabled={!isValid}>
+                        <option key={amt} value={amt}>
                           {amt} Gold = {amt} Influence
-                          {!isValid && ' (Not available)'}
                         </option>
                       )
                     })}
                   </select>
                 </div>
               )}
+              {gameState.pendingAction.type === ActionType.CLAIM &&
+                (() => {
+                  const validation = getClaimValidation()
+                  if (!validation?.valid) {
+                    return (
+                      <div
+                        style={{
+                          color: '#DC143C',
+                          fontSize: '0.8rem',
+                          marginTop: '0.5rem',
+                        }}
+                      >
+                        {validation?.message}
+                      </div>
+                    )
+                  }
+                  return null
+                })()}
               {gameState.challengeTargets && (
                 <div style={{ marginBottom: '1rem' }}>
                   <div

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -99,18 +99,20 @@ export const executeAction = (
     }
     case ActionType.CLAIM: {
       const amount = action.amount || 1
-      const location = getLocationSafe(newBoard, currentPlayer.position)
-      if (!location) break
+      const location = newBoard[currentPlayer.position]
       const currentInfluence = getLocationInfluence(location, currentPlayer.id)
-      const maxPossible = location.maxInfluence - currentInfluence
-      const actualAmount = Math.min(amount, maxPossible, currentPlayer.gold)
+      const maxSpace = location.maxInfluence - currentInfluence
+      const maxAffordable = currentPlayer.gold
+      const actualAmount = Math.min(amount, maxSpace, maxAffordable)
 
       if (actualAmount <= 0) {
+        // Can't claim anything
         console.warn('Cannot claim: insufficient space or gold')
         break
       }
 
       if (actualAmount < amount) {
+        // Log that we're claiming less than requested
         console.info(
           `Claiming ${actualAmount} instead of ${amount} due to constraints`
         )

--- a/tests/claim_validation.spec.ts
+++ b/tests/claim_validation.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test'
+
+test('claim amount dropdown shows correct options', async ({ page }) => {
+  await page.goto('/')
+  await page.getByRole('button', { name: 'Start Game' }).click()
+
+  await page.evaluate(() => {
+    const dispatch = (window as any).dispatchGameAction
+    const GamePhase = (window as any).GamePhase
+
+    dispatch({
+      type: 'SET_STATE',
+      payload: {
+        phase: GamePhase.PLAYER_TURN,
+        currentPlayer: 0,
+        players: [
+          {
+            id: 'player-0',
+            name: 'You',
+            character: { id: 'al', name: 'Al Swearengen', ability: '' },
+            position: 0,
+            gold: 2,
+            totalInfluence: 0,
+            isAI: false,
+            actionsRemaining: 2,
+          },
+        ],
+        board: Array(6)
+          .fill(null)
+          .map((_, i) => ({
+            id: i,
+            name: [
+              'Gem Saloon',
+              'Hardware Store',
+              'Bella Union',
+              'Sheriff Office',
+              'Freight Office',
+              "Wu's Pig Alley",
+            ][i],
+            influences: i === 0 ? { 'player-0': 1 } : {},
+            maxInfluence: 3,
+          })),
+        turnCount: 1,
+        completedActions: [],
+        pendingAction: undefined,
+        message: 'Your turn',
+        gameConfig: { playerCount: 1, aiDifficulty: 'medium' },
+      },
+    })
+  })
+
+  await page.getByRole('button', { name: /Claim/ }).click()
+
+  const dropdown = page.locator('select')
+
+  await expect(dropdown.locator('option:not([disabled])').nth(0)).toHaveText(
+    '1 Gold = 1 Influence'
+  )
+  await expect(dropdown.locator('option:not([disabled])').nth(1)).toHaveText(
+    '2 Gold = 2 Influence'
+  )
+
+  const option3 = dropdown.locator('option[value="3"]')
+  await expect(option3).toBeDisabled()
+  await expect(option3).toHaveText('3 Gold (Not available)')
+})
+
+test('claim validation prevents overspending', async ({ page }) => {
+  await page.goto('/')
+  await page.getByRole('button', { name: 'Start Game' }).click()
+
+  await page.evaluate(() => {
+    const dispatch = (window as any).dispatchGameAction
+    const state = (window as any).getGameState()
+
+    dispatch({
+      type: 'SET_STATE',
+      payload: {
+        ...state,
+        players: state.players.map((p: any, i: number) =>
+          i === 0 ? { ...p, gold: 1 } : p
+        ),
+      },
+    })
+  })
+
+  await page.getByRole('button', { name: /Claim/ }).click()
+
+  const dropdown = page.locator('select')
+  await expect(dropdown.locator('option[value="2"]')).toBeDisabled()
+
+  await dropdown.selectOption('1')
+  await page.getByRole('button', { name: /Confirm claim/i }).click()
+
+  const goldElement = page.locator('text=Gold:').locator('..').locator('strong').first()
+  await expect(goldElement).toHaveText('0')
+})
+
+test('location full prevents claiming', async ({ page }) => {
+  await page.goto('/')
+  await page.getByRole('button', { name: 'Start Game' }).click()
+
+  await page.evaluate(() => {
+    const dispatch = (window as any).dispatchGameAction
+    const state = (window as any).getGameState()
+    const playerId = state.players[0].id
+    const position = state.players[0].position
+
+    dispatch({
+      type: 'SET_STATE',
+      payload: {
+        ...state,
+        board: state.board.map((loc: any, i: number) =>
+          i === position ? { ...loc, influences: { [playerId]: 3 } } : loc
+        ),
+      },
+    })
+  })
+
+  const claimButton = page.getByRole('button', { name: /Claim/ })
+  await expect(claimButton).toBeDisabled()
+})

--- a/tests/unit/claim_validation.test.ts
+++ b/tests/unit/claim_validation.test.ts
@@ -1,31 +1,122 @@
 import { describe, it, expect } from 'vitest'
 import { executeAction } from '../../src/game/reducer'
-import { ActionType, type GameState, GamePhase } from '../../src/game/types'
+import { ActionType, GamePhase } from '../../src/game/types'
 import { createInitialBoard } from '../../src/game/board'
-import { createPlayers } from '../../src/game/players'
 
-const state: GameState = {
-  phase: GamePhase.PLAYER_TURN,
-  currentPlayer: 0,
-  players: createPlayers(1),
-  board: createInitialBoard(),
-  roundCount: 1,
-  gameConfig: { playerCount: 1, aiDifficulty: 'easy' },
-  actionHistory: [],
-  completedActions: [],
-  pendingAction: undefined,
-  message: '',
-}
+const makePlayer = (id: number, gold = 3, position = 0) => ({
+  id: `p${id}`,
+  name: `Player ${id}`,
+  character: { id: 'test', name: 'Test', ability: '', description: '' },
+  position,
+  gold,
+  totalInfluence: 0,
+  isAI: false,
+  actionsRemaining: 2,
+})
 
-state.players[0].gold = 3
-state.players[0].position = 0
-state.board[0].influences[state.players[0].id] = 2
+describe('claim amount validation', () => {
+  it('respects location space constraints', () => {
+    const board = createInitialBoard()
+    board[0].influences = { 'p0': 2 }
 
-describe('claim validation', () => {
-  it('respects constraints and only claims available space', () => {
-    const newState = executeAction(state, { type: ActionType.CLAIM, amount: 3 })
-    expect(newState.board[0].influences[state.players[0].id]).toBe(3)
+    const state = {
+      phase: GamePhase.PLAYER_TURN,
+      currentPlayer: 0,
+      players: [makePlayer(0, 3)],
+      board,
+      turnCount: 1,
+      gameConfig: { playerCount: 1, aiDifficulty: 'easy' as const },
+      actionHistory: [],
+      completedActions: [],
+      pendingAction: undefined,
+      message: '',
+    }
+
+    const newState = executeAction(state as any, {
+      type: ActionType.CLAIM,
+      amount: 3,
+    })
+
+    expect(newState.board[0].influences['p0']).toBe(3)
     expect(newState.players[0].gold).toBe(2)
     expect(newState.players[0].totalInfluence).toBe(1)
+  })
+
+  it('respects gold constraints', () => {
+    const state = {
+      phase: GamePhase.PLAYER_TURN,
+      currentPlayer: 0,
+      players: [makePlayer(0, 1)],
+      board: createInitialBoard(),
+      turnCount: 1,
+      gameConfig: { playerCount: 1, aiDifficulty: 'easy' as const },
+      actionHistory: [],
+      completedActions: [],
+      pendingAction: undefined,
+      message: '',
+    }
+
+    const newState = executeAction(state as any, {
+      type: ActionType.CLAIM,
+      amount: 3,
+    })
+
+    expect(newState.board[0].influences['p0']).toBe(1)
+    expect(newState.players[0].gold).toBe(0)
+    expect(newState.players[0].totalInfluence).toBe(1)
+  })
+
+  it('handles zero available claim gracefully', () => {
+    const board = createInitialBoard()
+    board[0].influences = { 'p0': 3 }
+
+    const state = {
+      phase: GamePhase.PLAYER_TURN,
+      currentPlayer: 0,
+      players: [makePlayer(0, 3)],
+      board,
+      turnCount: 1,
+      gameConfig: { playerCount: 1, aiDifficulty: 'easy' as const },
+      actionHistory: [],
+      completedActions: [],
+      pendingAction: undefined,
+      message: '',
+    }
+
+    const newState = executeAction(state as any, {
+      type: ActionType.CLAIM,
+      amount: 1,
+    })
+
+    expect(newState.board[0].influences['p0']).toBe(3)
+    expect(newState.players[0].gold).toBe(3)
+    expect(newState.players[0].totalInfluence).toBe(0)
+  })
+
+  it('claims correct amount when multiple constraints apply', () => {
+    const board = createInitialBoard()
+    board[0].influences = { 'p0': 1 }
+
+    const state = {
+      phase: GamePhase.PLAYER_TURN,
+      currentPlayer: 0,
+      players: [makePlayer(0, 2)],
+      board,
+      turnCount: 1,
+      gameConfig: { playerCount: 1, aiDifficulty: 'easy' as const },
+      actionHistory: [],
+      completedActions: [],
+      pendingAction: undefined,
+      message: '',
+    }
+
+    const newState = executeAction(state as any, {
+      type: ActionType.CLAIM,
+      amount: 3,
+    })
+
+    expect(newState.board[0].influences['p0']).toBe(3)
+    expect(newState.players[0].gold).toBe(0)
+    expect(newState.players[0].totalInfluence).toBe(2)
   })
 })


### PR DESCRIPTION
## Summary
- validate claim amounts in reducer and UI
- disable invalid claim dropdown options and show message
- add helper for claim validation
- update claim button availability check
- add unit and e2e tests for claim validation
- document progress in task log

## Testing
- `npm ci`
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68607db1c510832fa459887149721e82