### PR TITLE
Fix UI action state handling

### DIFF
--- a/docs/task-update.md
+++ b/docs/task-update.md
@@ -62,3 +62,10 @@
 - Added comprehensive Playwright tests covering all mechanics
 - Created helper functions and multiple scenarios
 - What's next: monitor CI performance and optimize if needed
+
+### [2025-06-29 14:35 UTC] Fix race condition and update tests
+
+- Added boolean attribute strings in LocationCard for reliable test queries
+- Introduced synchronous disabled action tracking to prevent multi-click issues
+- Adjusted startGame helper and round display waits in e2e tests
+- What's next: verify all tests pass

--- a/src/DeadwoodGame.tsx
+++ b/src/DeadwoodGame.tsx
@@ -35,6 +35,7 @@ const DeadwoodGame: React.FC = () => {
   const [disabledActions, setDisabledActions] = useState<Set<ActionType>>(
     new Set()
   )
+  const disabledRef = useRef<Set<ActionType>>(new Set())
 
   const currentPlayer = getPlayerSafe(
     gameState.players,
@@ -137,10 +138,13 @@ const DeadwoodGame: React.FC = () => {
       return
     }
 
-    setDisabledActions((prev) => new Set(prev).add(action))
+    if (disabledRef.current.has(action)) return
+    disabledRef.current.add(action)
+    setDisabledActions(new Set(disabledRef.current))
     dispatch({ type: 'SELECT_ACTION', payload: action })
     setTimeout(() => {
-      setDisabledActions(new Set())
+      disabledRef.current.delete(action)
+      setDisabledActions(new Set(disabledRef.current))
     }, 100)
   }
 

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -31,8 +31,8 @@ const LocationCard: React.FC<Props> = ({
     <div
       onClick={isValidTarget ? onClick : undefined}
       className={styles.card}
-      data-current={isCurrentLocation}
-      data-valid={isValidTarget}
+      data-current={isCurrentLocation ? 'true' : 'false'}
+      data-valid={isValidTarget ? 'true' : 'false'}
     >
       <h3 className={styles.title}>{location.name}</h3>
       {isValidTarget && showMoveCost !== undefined && showMoveCost > 0 && (

--- a/tests/complete_gameplay.spec.ts
+++ b/tests/complete_gameplay.spec.ts
@@ -14,7 +14,7 @@ async function startGame(page: Page, options?: { players?: number; difficulty?: 
   }
 
   await page.getByRole('button', { name: 'Start Game' }).click()
-  await expect(page.locator('text=Round 1')).toBeVisible()
+  await expect(page.locator('text=Round 1 \u2022')).toBeVisible()
 }
 
 async function waitForAI(page: Page, timeout = 5000) {

--- a/tests/round_display.spec.ts
+++ b/tests/round_display.spec.ts
@@ -95,7 +95,7 @@ test('round counter visible in all game states', async ({ page }) => {
       await page.getByRole('button', { name: /Rest/ }).click()
       await page.getByRole('button', { name: /Rest/ }).click()
     } else {
-      await page.waitForTimeout(3000)
+      await page.waitForTimeout(5000)
     }
   }
 


### PR DESCRIPTION
## Summary
- prevent rapid repeated action clicks by tracking disabled buttons with a ref
- set explicit data-valid/data-current attributes on location cards
- relax start game checks and AI wait times in tests
- document update

## Testing
- `npm run lint`
- `npm test` *(fails: 18 failing tests)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68614d74ea48832f80608887133147fb