### PR TITLE
Add requirements builder tools

### DIFF
--- a/.claude/LICENSE
+++ b/.claude/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 Claude Requirements Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,285 @@
+# Claude Requirements Gathering System
+
+An intelligent requirements gathering system for Claude Code that progressively builds context through automated discovery, asks simple yes/no questions, and generates comprehensive requirements documentation.
+
+## 🎯 Overview
+
+This system transforms the requirements gathering process by:
+- **Codebase-Aware Questions**: AI analyzes your code first, then asks informed questions
+- **Simple Yes/No Format**: All questions are yes/no with smart defaults - just say "idk" to use defaults
+- **Two-Phase Questioning**: 5 high-level questions for context, then 5 expert questions after code analysis  
+- **Automated Documentation**: Generates comprehensive specs with specific file paths and patterns
+- **Product Manager Friendly**: No code knowledge required to answer questions
+
+## 🚀 Quick Start
+
+```bash
+# Start gathering requirements for a new feature
+/requirements-start add user profile picture upload
+
+# Check progress and continue
+/requirements-status
+
+# View current requirement details
+/requirements-current
+
+# List all requirements
+/requirements-list
+
+# End current requirement gathering
+/requirements-end
+
+# Quick reminder if AI strays off course
+/remind
+```
+
+## 📁 Repository Structure
+
+```
+claude-requirements/
+├── commands/                     # Claude command definitions
+│   ├── requirements-start.md    # Begin new requirement
+│   ├── requirements-status.md   # Check progress (alias: current)
+│   ├── requirements-current.md  # View active requirement
+│   ├── requirements-end.md      # Finalize requirement
+│   ├── requirements-list.md     # List all requirements
+│   └── requirements-remind.md   # Remind AI of rules
+│
+├── requirements/                 # Requirement documentation storage
+│   ├── .current-requirement     # Tracks active requirement
+│   ├── index.md                 # Summary of all requirements
+│   └── YYYY-MM-DD-HHMM-name/   # Individual requirement folders
+│       ├── metadata.json        # Status and progress tracking
+│       ├── 00-initial-request.md    # User's original request
+│       ├── 01-discovery-questions.md # 5 context questions
+│       ├── 02-discovery-answers.md   # User's answers
+│       ├── 03-context-findings.md    # AI's code analysis
+│       ├── 04-detail-questions.md    # 5 expert questions
+│       ├── 05-detail-answers.md      # User's detailed answers
+│       └── 06-requirements-spec.md   # Final requirements
+│
+└── examples/                     # Example requirements
+```
+
+## 🔄 How It Works
+
+### Phase 1: Initial Setup & Codebase Analysis
+```
+User: /requirements-start add export functionality to reports
+```
+AI analyzes the entire codebase structure to understand the architecture, tech stack, and patterns.
+
+### Phase 2: Context Discovery Questions
+The AI asks 5 yes/no questions to understand the problem space:
+```
+Q1: Will users interact with this feature through a visual interface?
+(Default if unknown: YES - most features have UI components)
+
+User: yes
+
+Q2: Does this feature need to work on mobile devices?
+(Default if unknown: YES - mobile-first is standard)
+
+User: idk
+AI: ✓ Using default: YES
+
+[Continues through all 5 questions before recording answers]
+```
+
+### Phase 3: Targeted Context Gathering (Autonomous)
+AI autonomously:
+- Searches for specific files based on discovery answers
+- Reads relevant code sections
+- Analyzes similar features in detail
+- Documents technical constraints and patterns
+
+### Phase 4: Expert Requirements Questions
+With deep context, asks 5 detailed yes/no questions:
+```
+Q1: Should we use the existing ExportService at services/ExportService.ts?
+(Default if unknown: YES - maintains architectural consistency)
+
+User: yes
+
+Q2: Will PDF exports need custom formatting beyond the standard template?
+(Default if unknown: NO - standard template covers most use cases)
+
+User: no
+
+[Continues through all 5 questions before recording answers]
+```
+
+### Phase 5: Requirements Documentation
+Generates comprehensive spec with:
+- Problem statement and solution overview
+- Functional requirements from all 10 answers
+- Technical requirements with specific file paths
+- Implementation patterns to follow
+- Acceptance criteria
+
+## 📋 Command Reference
+
+### `/requirements-start [description]`
+Begins gathering requirements for a new feature or change.
+
+**Example:**
+```
+/requirements-start implement dark mode toggle
+```
+
+### `/requirements-status` or `/requirements-current`
+Shows current requirement progress and continues gathering.
+
+**Output:**
+```
+📋 Active Requirement: dark-mode-toggle
+Phase: Discovery Questions
+Progress: 3/5 questions answered
+
+Next: Q4: Should this sync across devices?
+```
+
+### `/requirements-end`
+Finalizes current requirement, even if incomplete.
+
+**Options:**
+1. Generate spec with current info
+2. Mark incomplete for later
+3. Cancel and delete
+
+### `/requirements-list`
+Shows all requirements with their status.
+
+**Output:**
+```
+✅ COMPLETE: dark-mode-toggle (Ready for implementation)
+🔴 ACTIVE: user-notifications (Discovery 3/5)
+⚠️ INCOMPLETE: data-export (Paused 3 days ago)
+```
+
+### `/remind` or `/requirements-remind`
+Reminds AI to follow requirements gathering rules.
+
+**Use when AI:**
+- Asks open-ended questions
+- Starts implementing code
+- Asks multiple questions at once
+
+## 🎯 Features
+
+### Smart Defaults
+Every question includes an intelligent default based on:
+- Best practices
+- Codebase patterns
+- Context discovered
+
+### Progressive Questioning
+- **Phase 1**: Analyzes codebase structure first
+- **Phase 2**: 5 high-level questions for product managers
+- **Phase 3**: Autonomous deep dive into relevant code
+- **Phase 4**: 5 expert questions based on code understanding
+
+### Automatic File Management
+- All files created automatically
+- Progress tracked between sessions
+- Can resume anytime
+
+### Integration Ready
+- Links to development sessions
+- References PRs and commits
+- Searchable requirement history
+
+## 💡 Best Practices
+
+### For Users
+1. **Be Specific**: Clear initial descriptions help AI ask better questions
+2. **Use Defaults**: "idk" is perfectly fine - defaults are well-reasoned
+3. **Stay Focused**: Use `/remind` if AI goes off track
+4. **Complete When Ready**: Don't feel obligated to answer every question
+
+### For Requirements
+1. **One Feature at a Time**: Keep requirements focused
+2. **Think Implementation**: Consider how another AI will use this
+3. **Document Decisions**: The "why" is as important as the "what"
+4. **Link Everything**: Connect requirements to sessions and PRs
+
+## 🔧 Installation
+
+1. Clone this repository:
+```bash
+git clone https://github.com/rizethereum/claude-code-requirements-builder.git
+```
+
+2. Copy the commands to your project:
+```bash
+cp -r commands ~/.claude/commands/
+# OR for project-specific
+cp -r commands /your/project/.claude/commands/
+```
+
+3. Create requirements directory:
+```bash
+mkdir -p requirements
+touch requirements/.current-requirement
+```
+
+4. Add to `.gitignore` if needed:
+```
+requirements/
+```
+
+## 📚 Examples
+
+### Feature Development
+```
+/requirements-start add user avatar upload
+# AI analyzes codebase structure
+# Answer 5 yes/no questions about the feature
+# AI autonomously researches relevant code
+# Answer 5 expert yes/no questions
+# Get comprehensive requirements doc with file paths
+```
+
+### Bug Fix Requirements
+```
+/requirements-start fix dashboard performance issues
+# Answer questions about scope
+# AI identifies problematic components
+# Answer questions about acceptable solutions
+# Get targeted fix requirements
+```
+
+### UI Enhancement
+```
+/requirements-start improve mobile navigation experience
+# Answer questions about current issues
+# AI analyzes existing navigation
+# Answer questions about desired behavior
+# Get detailed UI requirements
+```
+
+## 🤝 Contributing
+
+1. Fork the repository
+2. Create your feature branch
+3. Add new commands or improve existing ones
+4. Submit a pull request
+
+### Ideas for Contribution
+- Add requirement templates for common features
+- Create requirement validation commands
+- Build requirement-to-implementation tracking
+- Add multi-language question support
+
+## 📄 License
+
+MIT License - Feel free to use and modify for your projects.
+
+## 🙏 Acknowledgments
+
+Inspired by [@iannuttall](https://github.com/iannuttall)'s [claude-sessions](https://github.com/iannuttall/claude-sessions) project, which pioneered the concept of structured session management for Claude Code.
+
+---
+
+**Remember**: Good requirements today prevent confusion tomorrow!
+

--- a/.claude/commands/requirements-current.md
+++ b/.claude/commands/requirements-current.md
@@ -1,0 +1,75 @@
+# View Current Requirement
+
+Display detailed information about the active requirement.
+
+## Instructions:
+
+1. Read requirements/.current-requirement
+2. If no active requirement:
+   - Show "No active requirement"
+   - Display last 3 completed requirements
+   - Exit
+
+3. For active requirement:
+   - Load all files from requirement folder
+   - Display comprehensive status
+   - Show codebase analysis overview
+   - Show all questions and answers so far
+   - Display context findings if available
+   - Indicate current phase and next steps
+
+## File Structure:
+
+- 00-initial-request.md - Original user request
+- 01-discovery-questions.md - Context discovery questions
+- 02-discovery-answers.md - User's answers
+- 03-context-findings.md - AI's codebase analysis
+- 04-detail-questions.md - Expert requirements questions
+- 05-detail-answers.md - User's detailed answers
+- 06-requirements-spec.md - Final requirements document
+
+## Display Format:
+
+```
+📋 Current Requirement: [name]
+⏱️  Duration: [time since start]
+📊 Phase: [Initial Setup/Context Discovery/Targeted Context/Expert Requirements/Complete]
+🎯 Progress: [total answered]/[total questions]
+
+📄 Initial Request:
+[Show content from 00-initial-request.md]
+
+🏗️ Codebase Overview (Phase 1):
+- Architecture: [e.g., React + Node.js + PostgreSQL]
+- Main components: [identified services/modules]
+- Key patterns: [discovered conventions]
+
+✅ Context Discovery Phase (5/5 complete):
+Q1: Will users interact through a visual interface? YES
+Q2: Does this need to work on mobile? YES
+Q3: Will this handle sensitive data? NO
+Q4: Do users have a current workaround? YES (default)
+Q5: Will this need offline support? IDK → NO (default)
+
+🔍 Targeted Context Findings:
+- Specific files identified: [list key files]
+- Similar feature: UserProfile at components/UserProfile.tsx
+- Integration points: AuthService, ValidationService
+- Technical constraints: Rate limiting required
+
+🎯 Expert Requirements Phase (2/8 answered):
+Q1: Use existing ValidationService at services/validation.ts? YES
+Q2: Extend UserModel at models/User.ts? YES
+Q3: Add new API endpoint to routes/api/v1? [PENDING]
+...
+
+📝 Next Action:
+- Continue with /requirements-status
+- End early with /requirements-end
+```
+
+## Important:
+
+- This is view-only (doesn't continue gathering)
+- Shows complete history and context
+- Use /requirements-status to continue

--- a/.claude/commands/requirements-end.md
+++ b/.claude/commands/requirements-end.md
@@ -1,0 +1,85 @@
+# End Requirements Gathering
+
+Finalize the current requirement gathering session.
+
+## Instructions:
+
+1. Read requirements/.current-requirement
+2. If no active requirement:
+   - Show "No active requirement to end"
+   - Exit
+
+3. Show current status and ask user intent:
+
+   ```
+   ⚠️ Ending requirement: [name]
+   Current phase: [phase] ([X/Y] complete)
+
+   What would you like to do?
+   1. Generate spec with current information
+   2. Mark as incomplete for later
+   3. Cancel and delete
+   ```
+
+4. Based on choice:
+
+### Option 1: Generate Spec
+
+- Create 06-requirements-spec.md
+- Include all answered questions
+- Add defaults for unanswered with "ASSUMED:" prefix
+- Generate implementation hints
+- Update metadata status to "complete"
+
+### Option 2: Mark Incomplete
+
+- Update metadata status to "incomplete"
+- Add "lastUpdated" timestamp
+- Create summary of progress
+- Note what's still needed
+
+### Option 3: Cancel
+
+- Confirm deletion
+- Remove requirement folder
+- Clear .current-requirement
+
+## Final Spec Format:
+
+```markdown
+# Requirements Specification: [Name]
+
+Generated: [timestamp]
+Status: [Complete with X assumptions / Partial]
+
+## Overview
+
+[Problem statement and solution summary]
+
+## Detailed Requirements
+
+### Functional Requirements
+
+[Based on answered questions]
+
+### Technical Requirements
+
+- Affected files: [list with paths]
+- New components: [if any]
+- Database changes: [if any]
+
+### Assumptions
+
+[List any defaults used for unanswered questions]
+
+### Implementation Notes
+
+[Specific guidance for implementation]
+
+### Acceptance Criteria
+
+[Testable criteria for completion]
+```
+
+5. Clear .current-requirement
+6. Update requirements/index.md

--- a/.claude/commands/requirements-list.md
+++ b/.claude/commands/requirements-list.md
@@ -1,0 +1,64 @@
+# List All Requirements
+
+Display all requirements with their status and summaries.
+
+## Instructions:
+
+1. Check requirements/.current-requirement for active requirement
+2. List all folders in requirements/ directory
+3. For each requirement folder:
+   - Read metadata.json
+   - Extract key information
+   - Format for display
+
+4. Sort by:
+   - Active first (if any)
+   - Then by status: complete, incomplete
+   - Then by date (newest first)
+
+## Display Format:
+
+```
+📚 Requirements Documentation
+
+🔴 ACTIVE: profile-picture-upload
+   Phase: Discovery (3/5) | Started: 30m ago
+   Next: Q4 about file restrictions
+
+✅ COMPLETE:
+2025-01-26-0900-dark-mode-toggle
+   Status: Ready for implementation | 15 questions answered
+   Summary: Full theme system with user preferences
+   Linked PR: #234 (merged)
+
+2025-01-25-1400-export-reports
+   Status: Implemented | 22 questions answered
+   Summary: PDF/CSV export with filtering
+
+⚠️ INCOMPLETE:
+2025-01-24-1100-notification-system
+   Status: Paused at Detail phase (2/8) | Last: 2 days ago
+   Summary: Email/push notifications for events
+
+📈 Statistics:
+- Total: 4 requirements
+- Complete: 2 (13 avg questions)
+- Active: 1
+- Incomplete: 1
+```
+
+## Additional Features:
+
+1. Show linked artifacts:
+   - Development sessions
+   - Pull requests
+   - Implementation status
+
+2. Highlight stale requirements:
+   - Mark if incomplete > 7 days
+   - Suggest resuming or ending
+
+3. Quick actions:
+   - "View details: /requirements-show [id]"
+   - "Resume incomplete: /requirements-status"
+   - "Start new: /requirements-start [description]"

--- a/.claude/commands/requirements-remind.md
+++ b/.claude/commands/requirements-remind.md
@@ -1,0 +1,86 @@
+# Requirements Gathering Reminder
+
+Quick correction when deviating from requirements gathering rules.
+
+## Aliases:
+
+- /requirements-remind
+- /remind
+- /r
+
+## Instructions:
+
+1. Check requirements/.current-requirement
+2. If no active requirement:
+   - Show "No active requirement gathering session"
+   - Exit
+
+3. Display reminder based on current context:
+
+```
+🔔 Requirements Gathering Reminder
+
+You are gathering requirements for: [active-requirement]
+Current phase: [Initial Setup/Context Discovery/Targeted Context/Expert Requirements]
+Progress: [X/Y questions]
+
+📋 PHASE-SPECIFIC RULES:
+
+Phase 2 - Context Discovery:
+- ✅ Ask 5 yes/no questions about the problem space
+- ✅ Questions for product managers (no code knowledge required)
+- ✅ Focus on user workflows, not technical details
+- ✅ Write ALL questions before asking any
+- ✅ Record answers ONLY after all questions asked
+
+Phase 3 - Targeted Context (Autonomous):
+- ✅ Use RepoPrompt tools to search and read code
+- ✅ Analyze similar features and patterns
+- ✅ Document findings in context file
+- ❌ No user interaction during this phase
+
+Phase 4 - Expert Requirements:
+- ✅ Ask 5 detailed yes/no questions
+- ✅ Questions as if speaking to PM who knows no code
+- ✅ Clarify expected system behavior
+- ✅ Reference specific files when relevant
+- ✅ Record answers ONLY after all questions asked
+
+🚫 GENERAL RULES:
+1. ❌ Don't start coding or implementing
+2. ❌ Don't ask open-ended questions
+3. ❌ Don't record answers until ALL questions in phase are asked
+4. ❌ Don't exceed 5 questions per phase
+
+📍 CURRENT STATE:
+- Last question: [Show last question]
+- User response: [pending/answered]
+- Next action: [Continue with question X of 5]
+
+Please continue with the current question or read the next one from the file.
+```
+
+## Common Correction Scenarios:
+
+### Open-ended question asked:
+
+"Let me rephrase as a yes/no question..."
+
+### Multiple questions asked:
+
+"Let me ask one question at a time..."
+
+### Implementation started:
+
+"I apologize. Let me continue with requirements gathering..."
+
+### No default provided:
+
+"Let me add a default for that question..."
+
+## Auto-trigger Patterns:
+
+- Detect code blocks → remind no implementation
+- Multiple "?" in response → remind one question
+- Response > 100 words → remind to be concise
+- Open-ended words ("what", "how") → remind yes/no only

--- a/.claude/commands/requirements-start.md
+++ b/.claude/commands/requirements-start.md
@@ -1,0 +1,132 @@
+# Start Requirements Gathering
+
+Begin gathering requirements for: $ARGUMENTS
+
+## Full Workflow:
+
+### Phase 1: Initial Setup & Codebase Analysis
+
+1. Create timestamp-based folder: requirements/YYYY-MM-DD-HHMM-[slug]
+2. Extract slug from $ARGUMENTS (e.g., "add user profile" → "user-profile")
+3. Create initial files:
+   - 00-initial-request.md with the user's request
+   - metadata.json with status tracking
+4. Read and update requirements/.current-requirement with folder name
+5. Use mcp**RepoPrompt**get_file_tree (if available) to understand overall structure:
+   - Get high-level architecture overview
+   - Identify main components and services
+   - Understand technology stack
+   - Note patterns and conventions
+
+### Phase 2: Context Discovery Questions
+
+6. Generate the five most important yes/no questions to understand the problem space:
+   - Questions informed by codebase structure
+   - Questions about user interactions and workflows
+   - Questions about similar features users currently use
+   - Questions about data/content being worked with
+   - Questions about external integrations or third-party services
+   - Questions about performance or scale expectations
+   - Write all questions to 01-discovery-questions.md with smart defaults
+   - Begin asking questions one at a time proposing the question with a smart default option
+   - Only after all questions are asked, record answers in 02-discovery-answers.md as received and update metadata.json. Not before.
+
+### Phase 3: Targeted Context Gathering (Autonomous)
+
+7. After all discovery questions answered:
+   - Use mcp**RepoPrompt**search (if available) to find specific files based on discovery answers
+   - Use mcp**RepoPrompt**set_selection and read_selected_files (if available) to batch read relevant code
+   - Deep dive into similar features and patterns
+   - Analyze specific implementation details
+   - Use WebSearch and or context7 for best practices or library documentation
+   - Document findings in 03-context-findings.md including:
+     - Specific files that need modification
+     - Exact patterns to follow
+     - Similar features analyzed in detail
+     - Technical constraints and considerations
+     - Integration points identified
+
+### Phase 4: Expert Requirements Questions
+
+8. Now ask questions like a senior developer who knows the codebase:
+   - Write the top 5 most pressing unanswered detailed yes/no questions to 04-detail-questions.md
+   - Questions should be as if you were speaking to the product manager who knows nothing of the code
+   - These questions are meant to to clarify expected system behavior now that you have a deep understanding of the code
+   - Include smart defaults based on codebase patterns
+   - Ask questions one at a time
+   - Only after all questions are asked, record answers in 05-detail-answers.md as received
+
+### Phase 5: Requirements Documentation
+
+9. Generate comprehensive requirements spec in 06-requirements-spec.md:
+   - Problem statement and solution overview
+   - Functional requirements based on all answers
+   - Technical requirements with specific file paths
+   - Implementation hints and patterns to follow
+   - Acceptance criteria
+   - Assumptions for any unanswered questions
+
+## Question Formats:
+
+### Discovery Questions (Phase 2):
+
+```
+## Q1: Will users interact with this feature through a visual interface?
+**Default if unknown:** Yes (most features have some UI component)
+
+## Q2: Does this feature need to work on mobile devices?
+**Default if unknown:** Yes (mobile-first is standard practice)
+
+## Q3: Will this feature handle sensitive or private user data?
+**Default if unknown:** Yes (better to be secure by default)
+
+## Q4: Do users currently have a workaround for this problem?
+**Default if unknown:** No (assuming this solves a new need)
+
+## Q5: Will this feature need to work offline?
+**Default if unknown:** No (most features require connectivity)
+```
+
+### Expert Questions (Phase 4):
+
+```
+## Q7: Should we extend the existing UserService at services/UserService.ts?
+**Default if unknown:** Yes (maintains architectural consistency)
+
+## Q8: Will this require new database migrations in db/migrations/?
+**Default if unknown:** No (based on similar features not requiring schema changes)
+```
+
+## Important Rules:
+
+- ONLY yes/no questions with smart defaults
+- ONE question at a time
+- Write ALL questions to file BEFORE asking any
+- Stay focused on requirements (no implementation)
+- Use actual file paths and component names in detail phase
+- Document WHY each default makes sense
+- Use tools available if recommended ones aren't installed or available
+
+## Metadata Structure:
+
+```json
+{
+  "id": "feature-slug",
+  "started": "ISO-8601-timestamp",
+  "lastUpdated": "ISO-8601-timestamp",
+  "status": "active",
+  "phase": "discovery|context|detail|complete",
+  "progress": {
+    "discovery": { "answered": 0, "total": 5 },
+    "detail": { "answered": 0, "total": 0 }
+  },
+  "contextFiles": ["paths/of/files/analyzed"],
+  "relatedFeatures": ["similar features found"]
+}
+```
+
+## Phase Transitions:
+
+- After each phase, announce: "Phase complete. Starting [next phase]..."
+- Save all work before moving to next phase
+- User can check progress anytime with /requirements-status

--- a/.claude/commands/requirements-status.md
+++ b/.claude/commands/requirements-status.md
@@ -1,0 +1,45 @@
+# Check Requirements Status
+
+Show current requirement gathering progress and continue.
+
+## Instructions:
+
+1. Read requirements/.current-requirement
+2. If no active requirement:
+   - Show message: "No active requirement gathering"
+   - Suggest /requirements-start or /requirements-list
+   - Exit
+
+3. If active requirement exists:
+   - Read metadata.json for current phase and progress
+   - Show formatted status
+   - Load appropriate question/answer files
+   - Continue from last unanswered question
+
+## Status Display Format:
+
+```
+📋 Active Requirement: [name]
+Started: [time ago]
+Phase: [Discovery/Detail]
+Progress: [X/Y] questions answered
+
+[Show last 3 answered questions with responses]
+
+Next Question:
+[Show next unanswered question with default]
+```
+
+## Continuation Flow:
+
+1. Read next unanswered question from file
+2. Present to user with default
+3. Accept yes/no/idk response
+4. Update answer file
+5. Update metadata progress
+6. Move to next question or phase
+
+## Phase Transitions:
+
+- Discovery complete → Run context gathering → Generate detail questions
+- Detail complete → Generate final requirements spec

--- a/.claude/examples/2025-01-27-1430-user-authentication/00-initial-request.md
+++ b/.claude/examples/2025-01-27-1430-user-authentication/00-initial-request.md
@@ -1,0 +1,10 @@
+# Initial Request
+
+**Timestamp**: 2025-01-27 14:30:00
+**User**: /requirements-start implement user authentication with email and password
+
+## Extracted Details
+
+- Feature: User authentication
+- Type: Email and password based
+- Implied needs: Login, registration, password reset

--- a/.claude/examples/2025-01-27-1430-user-authentication/01-discovery-questions.md
+++ b/.claude/examples/2025-01-27-1430-user-authentication/01-discovery-questions.md
@@ -1,0 +1,25 @@
+# Discovery Questions
+
+## Q1: Will this be the primary authentication method for your application?
+
+**Default if unknown:** Yes (most apps start with email/password auth)
+
+## Q2: Do you need social authentication providers (Google, GitHub, etc.) as well?
+
+**Default if unknown:** No (can be added later if needed)
+
+## Q3: Should users verify their email address before accessing the app?
+
+**Default if unknown:** Yes (standard security practice)
+
+## Q4: Will you need role-based access control (admin, user, etc.)?
+
+**Default if unknown:** Yes (most apps need at least basic roles)
+
+## Q5: Should the system support "Remember Me" functionality?
+
+**Default if unknown:** Yes (improves user experience)
+
+## Q6: Do you need two-factor authentication support?
+
+**Default if unknown:** No (can be added later for enhanced security)

--- a/.claude/examples/2025-01-27-1430-user-authentication/02-discovery-answers.md
+++ b/.claude/examples/2025-01-27-1430-user-authentication/02-discovery-answers.md
@@ -1,0 +1,25 @@
+# Discovery Answers
+
+## Q1: Will this be the primary authentication method?
+
+**Answer**: YES
+
+## Q2: Need social authentication providers?
+
+**Answer**: NO
+
+## Q3: Email verification required?
+
+**Answer**: YES
+
+## Q4: Role-based access control?
+
+**Answer**: IDK → YES (default)
+
+## Q5: "Remember Me" functionality?
+
+**Answer**: YES
+
+## Q6: Two-factor authentication?
+
+**Answer**: NO

--- a/.claude/examples/2025-01-27-1430-user-authentication/06-requirements-spec.md
+++ b/.claude/examples/2025-01-27-1430-user-authentication/06-requirements-spec.md
@@ -1,0 +1,136 @@
+# Requirements Specification: User Authentication
+
+**Generated**: 2025-01-27 15:45:00  
+**Status**: Complete  
+**Questions Answered**: 14/14
+
+## Overview
+
+Implement a complete email/password authentication system with email verification, role-based access control, and "Remember Me" functionality. This will be the primary authentication method for the application.
+
+## Functional Requirements
+
+### User Registration
+
+- Email and password signup form
+- Password strength requirements (min 8 chars, 1 uppercase, 1 number)
+- Email uniqueness validation
+- Send verification email upon registration
+- Prevent login until email verified
+
+### User Login
+
+- Email/password authentication
+- "Remember Me" checkbox (30-day token)
+- Show appropriate error messages
+- Redirect to intended page after login
+- Session management with JWT tokens
+
+### Password Reset
+
+- "Forgot Password" link on login
+- Send reset email with secure token
+- Token expires after 1 hour
+- Require new password to meet strength requirements
+
+### Email Verification
+
+- Send verification link via email
+- Link expires after 24 hours
+- Resend verification option
+- Clear feedback on verification status
+
+## Technical Requirements
+
+### Backend Components
+
+- **Database Schema**:
+  - Users table (id, email, password_hash, role, verified, created_at)
+  - Sessions table (token, user_id, expires_at, remember_me)
+  - Password_resets table (token, user_id, expires_at)
+
+- **API Endpoints**:
+  - POST /api/auth/register
+  - POST /api/auth/login
+  - POST /api/auth/logout
+  - POST /api/auth/verify-email
+  - POST /api/auth/forgot-password
+  - POST /api/auth/reset-password
+  - GET /api/auth/me
+
+- **Middleware**:
+  - Authentication middleware for protected routes
+  - Role-based authorization middleware
+
+### Frontend Components
+
+- **Pages**:
+  - /auth/login - Login form
+  - /auth/register - Registration form
+  - /auth/forgot-password - Password reset request
+  - /auth/reset-password - New password form
+  - /auth/verify-email - Email verification handler
+
+- **Components**:
+  - AuthForm component (shared styling)
+  - PasswordInput with visibility toggle
+  - EmailInput with validation
+  - AuthError component for messages
+
+### Security Considerations
+
+- Bcrypt for password hashing (10 rounds)
+- JWT tokens with httpOnly cookies
+- CSRF protection on all forms
+- Rate limiting on auth endpoints
+- Secure random tokens for reset/verification
+
+## Implementation Notes
+
+### Suggested Libraries
+
+- **Backend**: Express + Passport.js or custom JWT
+- **Frontend**: React Hook Form for validation
+- **Email**: SendGrid or AWS SES
+- **Validation**: Joi or Yup schemas
+
+### File Structure
+
+```
+backend/
+  routes/auth.js
+  middleware/auth.js
+  models/User.js
+  services/EmailService.js
+
+frontend/
+  pages/auth/
+  components/auth/
+  hooks/useAuth.js
+  contexts/AuthContext.js
+```
+
+## Acceptance Criteria
+
+- [ ] User can register with email/password
+- [ ] Registration fails with existing email
+- [ ] User receives verification email
+- [ ] User cannot login until verified
+- [ ] User can login with correct credentials
+- [ ] "Remember Me" keeps user logged in
+- [ ] User can reset forgotten password
+- [ ] Password reset link expires properly
+- [ ] Protected routes require authentication
+- [ ] Admin routes require admin role
+- [ ] Logout clears all sessions
+- [ ] All forms show validation errors
+- [ ] All auth actions show loading states
+
+## Future Enhancements
+
+- Social authentication providers
+- Two-factor authentication
+- Account lockout after failed attempts
+- Password change from profile
+- Login history tracking
+- Device management

--- a/docs/task-update.md
+++ b/docs/task-update.md
@@ -69,3 +69,13 @@
 - Introduced synchronous disabled action tracking to prevent multi-click issues
 - Adjusted startGame helper and round display waits in e2e tests
 - What's next: verify all tests pass
+
+### [2025-06-29 15:28 UTC] Add requirements builder files
+
+- Added rizethereum-claude-code-requirements-builder directory with commands, examples, and docs
+- What's next: ensure tests pass and monitor integration
+
+### [2025-06-29 16:08 UTC] Move requirements builder
+
+- Relocated files into `.claude` directory and removed subdirectory
+- What's next: verify tests pass


### PR DESCRIPTION
## Summary
- add `rizethereum-claude-code-requirements-builder` with commands and example requirements
- document change in `docs/task-update.md`

## Testing
- `npm ci`
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68615a7de34c832fb4d9c5b3e84fc51b