### PR TITLE
Fix lint formatting

### DIFF
--- a/docs/task-update.md
+++ b/docs/task-update.md
@@ -69,8 +69,16 @@
 - Introduced synchronous disabled action tracking to prevent multi-click issues
 - Adjusted startGame helper and round display waits in e2e tests
 - What's next: verify all tests pass
+
 ### [2025-06-29 15:30 UTC] Attempt to stabilize tests
+
 - Reworked action disable logic in DeadwoodGame to remove temporary disabling
 - Added small waits in action_race_condition Playwright tests
 - Tests still failing; further debugging required
 - What's next: investigate failing Playwright scenarios in depth
+
+### [2025-06-29 16:12 UTC] Fix lint errors
+
+- Formatted docs/task-update.md with Prettier
+- Ran lint, tests (failing), and build
+- What\x27s next: address failing tests


### PR DESCRIPTION
## Summary
- fix Prettier formatting for task-update

## Testing
- `npm run lint`
- `npm test` *(fails: cannot select action etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686164f623d4832faa5f2228dd96b556