### PR TITLE
Add AI turn failsafe

### DIFF
--- a/docs/task-update.md
+++ b/docs/task-update.md
@@ -79,3 +79,9 @@
 
 - Relocated files into `.claude` directory and removed subdirectory
 - What's next: verify tests pass
+
+### [2025-06-29 16:27 UTC] Add AI turn failsafe
+
+- Implemented automatic end-turn timer for AI players
+- Clear failsafe on turn completion or exit
+- What's next: monitor AI behavior under stress


### PR DESCRIPTION
## Summary
- add backup timer to automatically end stuck AI turns
- document progress

## Testing
- `npm ci`
- `npm run lint`
- `npm test` *(fails: 18 failed, 32 passed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68616828d52c832f97b3bd19f51a535b