### PR TITLE
Color code influence stars

### DIFF
--- a/docs/task-update.md
+++ b/docs/task-update.md
@@ -85,3 +85,10 @@
 - Implemented automatic end-turn timer for AI players
 - Clear failsafe on turn completion or exit
 - What's next: monitor AI behavior under stress
+
+### [2025-06-29 17:23 UTC] Color code influence stars
+
+- Added `color` property to `Player` type and assigned colors on player creation
+- Updated LocationCard to style influence stars using each player's color
+- Adjusted unit and e2e tests for new property
+- What's next: ensure tests and build succeed

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -48,6 +48,10 @@ const LocationCard: React.FC<Props> = ({
                 key={playerId}
                 className={styles.influence}
                 data-current={playerId === currentPlayerId}
+                style={{
+                  color:
+                    playerId === currentPlayerId ? '#006400' : player.color,
+                }}
               >
                 {'★'.repeat(influence)}
               </div>

--- a/src/game/players.ts
+++ b/src/game/players.ts
@@ -28,6 +28,8 @@ export const CHARACTERS: Character[] = [
   },
 ]
 
+export const PLAYER_COLORS = ['#ff4500', '#1e90ff', '#32cd32', '#ffd700']
+
 export const createPlayers = (playerCount: number): Player[] => {
   const shuffledCharacters = [...CHARACTERS].sort(() => Math.random() - 0.5)
   const players: Player[] = []
@@ -36,6 +38,7 @@ export const createPlayers = (playerCount: number): Player[] => {
       id: `player-${i}`,
       name: i === 0 ? 'You' : `AI Player ${i}`,
       character: shuffledCharacters[i],
+      color: PLAYER_COLORS[i % PLAYER_COLORS.length],
       position: Math.floor(Math.random() * LOCATIONS.length),
       gold: 3,
       totalInfluence: 0,

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -14,6 +14,7 @@ export interface Player {
   id: string
   name: string
   character: Character
+  color: string
   position: number
   gold: number
   totalInfluence: number

--- a/tests/ai_flow_complete.spec.ts
+++ b/tests/ai_flow_complete.spec.ts
@@ -20,6 +20,7 @@ test('AI completes its turn automatically', async ({ page }) => {
           {
             id: 'player-0',
             name: 'AI 1',
+            color: '#000',
             position: 0,
             gold: 3,
             totalInfluence: 0,
@@ -30,6 +31,7 @@ test('AI completes its turn automatically', async ({ page }) => {
           {
             id: 'player-1',
             name: 'AI 2',
+            color: '#000',
             position: 1,
             gold: 3,
             totalInfluence: 0,

--- a/tests/ai_timer_safety.spec.ts
+++ b/tests/ai_timer_safety.spec.ts
@@ -21,6 +21,7 @@ test('AI actions are cancelled when game ends', async ({ page }) => {
           {
             id: 'player-0',
             name: 'You',
+            color: '#000',
             totalInfluence: 11,
             gold: 3,
             position: 0,
@@ -31,6 +32,7 @@ test('AI actions are cancelled when game ends', async ({ page }) => {
           {
             id: 'player-1',
             name: 'AI Player 1',
+            color: '#000',
             isAI: true,
             position: 1,
             gold: 3,

--- a/tests/bounds_safety.spec.ts
+++ b/tests/bounds_safety.spec.ts
@@ -52,6 +52,7 @@ test('challenge with invalid target index', async ({ page }) => {
           {
             id: 'player-0',
             name: 'Test',
+            color: '#000',
             position: 0,
             gold: 3,
             totalInfluence: 0,

--- a/tests/challenge_flow.spec.ts
+++ b/tests/challenge_flow.spec.ts
@@ -18,6 +18,7 @@ test('challenge action targets correct player', async ({ page }) => {
           {
             id: 'player-0',
             name: 'You',
+            color: '#000',
             character: { id: 'al', name: 'Al Swearengen', ability: '' },
             position: 0,
             gold: 5,
@@ -28,6 +29,7 @@ test('challenge action targets correct player', async ({ page }) => {
           {
             id: 'player-1',
             name: 'AI Player 1',
+            color: '#000',
             character: { id: 'seth', name: 'Seth Bullock', ability: '' },
             position: 0,
             gold: 3,

--- a/tests/challenge_validation.spec.ts
+++ b/tests/challenge_validation.spec.ts
@@ -17,6 +17,7 @@ test('cannot challenge player with no influence', async ({ page }) => {
           {
             id: 'player-0',
             name: 'You',
+            color: '#000',
             character: {
               id: 'seth',
               name: 'Seth Bullock',
@@ -31,6 +32,7 @@ test('cannot challenge player with no influence', async ({ page }) => {
           {
             id: 'player-1',
             name: 'AI Player 1',
+            color: '#000',
             character: { id: 'al', name: 'Al Swearengen', ability: '' },
             position: 0,
             gold: 3,
@@ -91,6 +93,7 @@ test('challenge only deducts gold when successful', async ({ page }) => {
           {
             id: 'player-0',
             name: 'You',
+            color: '#000',
             character: {
               id: 'seth',
               name: 'Seth Bullock',
@@ -105,6 +108,7 @@ test('challenge only deducts gold when successful', async ({ page }) => {
           {
             id: 'player-1',
             name: 'AI Player 1',
+            color: '#000',
             character: { id: 'al', name: 'Al Swearengen', ability: '' },
             position: 0,
             gold: 3,

--- a/tests/claim_validation.spec.ts
+++ b/tests/claim_validation.spec.ts
@@ -17,6 +17,7 @@ test('claim amount dropdown shows correct options', async ({ page }) => {
           {
             id: 'player-0',
             name: 'You',
+            color: '#000',
             character: { id: 'al', name: 'Al Swearengen', ability: '' },
             position: 0,
             gold: 2,

--- a/tests/complete_gameplay.spec.ts
+++ b/tests/complete_gameplay.spec.ts
@@ -136,6 +136,7 @@ test.describe('Victory Conditions', () => {
             {
               id: 'player-0',
               name: 'You',
+              color: '#000',
               character: { id: 'al', name: 'Al Swearengen', ability: '' },
               position: 0,
               gold: 3,
@@ -146,6 +147,7 @@ test.describe('Victory Conditions', () => {
             {
               id: 'player-1',
               name: 'AI Player 1',
+              color: '#000',
               character: { id: 'seth', name: 'Seth Bullock', ability: '' },
               position: 1,
               gold: 3,
@@ -197,6 +199,7 @@ test.describe('Victory Conditions', () => {
             {
               id: 'player-0',
               name: 'You',
+              color: '#000',
               character: { id: 'al', name: 'Al Swearengen', ability: '' },
               position: 2, // Bella Union
               gold: 3,
@@ -207,6 +210,7 @@ test.describe('Victory Conditions', () => {
             {
               id: 'player-1',
               name: 'AI Player 1',
+              color: '#000',
               character: { id: 'seth', name: 'Seth Bullock', ability: '' },
               position: 3,
               gold: 3,
@@ -260,6 +264,7 @@ test.describe('Victory Conditions', () => {
             {
               id: 'player-0',
               name: 'You',
+              color: '#000',
               character: { id: 'al', name: 'Al Swearengen', ability: '' },
               position: 0,
               gold: 10,
@@ -270,6 +275,7 @@ test.describe('Victory Conditions', () => {
             {
               id: 'player-1',
               name: 'AI Player 1',
+              color: '#000',
               character: { id: 'seth', name: 'Seth Bullock', ability: '' },
               position: 1,
               gold: 5,
@@ -324,6 +330,7 @@ test.describe('Character Abilities', () => {
             {
               id: 'player-0',
               name: 'You',
+              color: '#000',
               character: { id: 'seth', name: 'Seth Bullock', ability: '' },
               position: 1, // Hardware Store
               gold: 3,
@@ -334,6 +341,7 @@ test.describe('Character Abilities', () => {
             {
               id: 'player-1',
               name: 'Al',
+              color: '#000',
               character: {
                 id: 'al',
                 name: 'Al Swearengen',
@@ -389,6 +397,7 @@ test.describe('Character Abilities', () => {
             {
               id: 'player-0',
               name: 'You',
+              color: '#000',
               character: {
                 id: 'seth',
                 name: 'Seth Bullock',
@@ -403,6 +412,7 @@ test.describe('Character Abilities', () => {
             {
               id: 'player-1',
               name: 'AI Player 1',
+              color: '#000',
               character: { id: 'al', name: 'Al Swearengen', ability: '' },
               position: 0,
               gold: 3,
@@ -455,6 +465,7 @@ test.describe('Character Abilities', () => {
             {
               id: 'player-0',
               name: 'You',
+              color: '#000',
               character: {
                 id: 'cy',
                 name: 'Cy Tolliver',
@@ -469,6 +480,7 @@ test.describe('Character Abilities', () => {
             {
               id: 'player-1',
               name: 'Target',
+              color: '#000',
               character: { id: 'al', name: 'Al Swearengen', ability: '' },
               position: 1, // Hardware Store (adjacent)
               gold: 3,
@@ -526,6 +538,7 @@ test.describe('Character Abilities', () => {
             {
               id: 'player-0',
               name: 'You',
+              color: '#000',
               character: {
                 id: 'jane',
                 name: 'Calamity Jane',
@@ -583,6 +596,7 @@ test.describe('Game Mechanics', () => {
             {
               id: 'player-0',
               name: 'You',
+              color: '#000',
               character: { id: 'al', name: 'Al Swearengen', ability: '' },
               position: 0,
               gold: 5,
@@ -644,6 +658,7 @@ test.describe('Game Mechanics', () => {
             {
               id: 'player-0',
               name: 'You',
+              color: '#000',
               character: { id: 'al', name: 'Al Swearengen', ability: '' },
               position: 0,
               gold: 3,
@@ -654,6 +669,7 @@ test.describe('Game Mechanics', () => {
             {
               id: 'player-1',
               name: 'AI Player 1',
+              color: '#000',
               character: { id: 'seth', name: 'Seth Bullock', ability: '' },
               position: 0,
               gold: 3,
@@ -712,6 +728,7 @@ test.describe('Game Mechanics', () => {
             {
               id: 'player-0',
               name: 'You',
+              color: '#000',
               character: { id: 'al', name: 'Al Swearengen', ability: '' },
               position: 0,
               gold: 5,
@@ -722,6 +739,7 @@ test.describe('Game Mechanics', () => {
             {
               id: 'player-1',
               name: 'AI Player 1',
+              color: '#000',
               character: { id: 'seth', name: 'Seth Bullock', ability: '' },
               position: 0,
               gold: 3,
@@ -732,6 +750,7 @@ test.describe('Game Mechanics', () => {
             {
               id: 'player-2',
               name: 'AI Player 2',
+              color: '#000',
               character: { id: 'cy', name: 'Cy Tolliver', ability: '' },
               position: 0,
               gold: 3,
@@ -843,6 +862,7 @@ test.describe('Error Handling', () => {
             {
               id: 'player-0',
               name: 'You',
+              color: '#000',
               character: { id: 'al', name: 'Al Swearengen', ability: '' },
               position: 0,
               gold: 0, // No gold

--- a/tests/round_display.spec.ts
+++ b/tests/round_display.spec.ts
@@ -35,6 +35,7 @@ test('game ends after 20 complete rounds', async ({ page }) => {
           {
             id: 'player-0',
             name: 'You',
+            color: '#000',
             character: { id: 'al', name: 'Al Swearengen', ability: '' },
             position: 0,
             gold: 10,
@@ -45,6 +46,7 @@ test('game ends after 20 complete rounds', async ({ page }) => {
           {
             id: 'player-1',
             name: 'AI Player 1',
+            color: '#000',
             character: { id: 'seth', name: 'Seth Bullock', ability: '' },
             position: 1,
             gold: 5,

--- a/tests/unit/abilities.test.ts
+++ b/tests/unit/abilities.test.ts
@@ -8,6 +8,7 @@ const makePlayer = (charIndex: number, position: number) => ({
   id: `p${charIndex}`,
   name: `P${charIndex}`,
   character: CHARACTERS[charIndex],
+  color: '#000',
   position,
   gold: 3,
   totalInfluence: 0,

--- a/tests/unit/challenge_validation.test.ts
+++ b/tests/unit/challenge_validation.test.ts
@@ -9,6 +9,7 @@ const makePlayer = (charIndex: number, position = 0, gold = 3) => ({
   id: `p${charIndex}`,
   name: `P${charIndex}`,
   character: CHARACTERS[charIndex],
+  color: '#000',
   position,
   gold,
   totalInfluence: 0,

--- a/tests/unit/claim_validation.test.ts
+++ b/tests/unit/claim_validation.test.ts
@@ -7,6 +7,7 @@ const makePlayer = (id: number, gold = 3, position = 0) => ({
   id: `p${id}`,
   name: `Player ${id}`,
   character: { id: 'test', name: 'Test', ability: '', description: '' },
+  color: '#000',
   position,
   gold,
   totalInfluence: 0,

--- a/tests/unit/reducer.test.ts
+++ b/tests/unit/reducer.test.ts
@@ -54,6 +54,7 @@ const makePlayer = (index: number, position = 0) => ({
   id: `player-${index}`,
   name: `Player ${index}`,
   character: CHARACTERS[index % CHARACTERS.length],
+  color: '#000',
   position,
   gold: 3,
   totalInfluence: 0,

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -6,6 +6,7 @@ const makePlayer = (characterIndex: number, position = 0) => ({
   id: `p${characterIndex}`,
   name: `P${characterIndex}`,
   character: CHARACTERS[characterIndex],
+  color: '#000',
   position,
   gold: 3,
   totalInfluence: 0,

--- a/tests/unit/victory.test.ts
+++ b/tests/unit/victory.test.ts
@@ -8,6 +8,7 @@ const makePlayer = (charIndex: number) => ({
   id: `p${charIndex}`,
   name: `P${charIndex}`,
   character: CHARACTERS[charIndex],
+  color: '#000',
   position: 0,
   gold: 3,
   totalInfluence: 0,

--- a/tests/victory_timing.spec.ts
+++ b/tests/victory_timing.spec.ts
@@ -16,6 +16,7 @@ test('game ends immediately when reaching 12 influence', async ({ page }) => {
           {
             id: 'player-0',
             name: 'You',
+            color: '#000',
             character: { id: 'al', name: 'Al Swearengen', ability: '' },
             position: 0,
             gold: 3,
@@ -26,6 +27,7 @@ test('game ends immediately when reaching 12 influence', async ({ page }) => {
           {
             id: 'player-1',
             name: 'AI Player 1',
+            color: '#000',
             character: { id: 'seth', name: 'Seth Bullock', ability: '' },
             position: 1,
             gold: 3,
@@ -83,6 +85,7 @@ test('game ends after first action with location control victory', async ({ page
           {
             id: 'player-0',
             name: 'You',
+            color: '#000',
             character: { id: 'al', name: 'Al Swearengen', ability: '' },
             position: 2,
             gold: 3,
@@ -93,6 +96,7 @@ test('game ends after first action with location control victory', async ({ page
           {
             id: 'player-1',
             name: 'AI Player 1',
+            color: '#000',
             character: { id: 'seth', name: 'Seth Bullock', ability: '' },
             position: 3,
             gold: 3,


### PR DESCRIPTION
## Summary
- add `color` property to Player type and player creation
- show influence stars in each player's color
- update unit/e2e tests for new property
- record progress in task update log

## Testing
- `npm ci`
- `npm run lint`
- `npm test` *(fails: 18 failed, 32 passed)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686174a0ec28832f9b24a7146e4b6232