### PR TITLE
Add influence star persistence e2e test

### DIFF
--- a/docs/task-update.md
+++ b/docs/task-update.md
@@ -92,3 +92,8 @@
 - Updated LocationCard to style influence stars using each player's color
 - Adjusted unit and e2e tests for new property
 - What's next: ensure tests and build succeed
+
+### [2025-06-29 17:47 UTC] Add influence persistence test
+
+- Created Playwright spec to ensure claim stars remain visible after reaching three influence
+- What's next: verify tests and build succeed

--- a/tests/influence_persistence.spec.ts
+++ b/tests/influence_persistence.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test'
+
+async function startGame(page) {
+  await page.goto('/')
+  await page.getByRole('button', { name: 'Start Game' }).click()
+  await expect(page.locator('text=Round 1 \u2022')).toBeVisible()
+}
+
+function getLocationCard(page, name: string) {
+  return page
+    .locator('div')
+    .filter({ has: page.locator(`h3:text("${name}")`) })
+    .first()
+}
+
+test('influence stars persist after reaching three', async ({ page }) => {
+  await startGame(page)
+
+  // Claim 2 influence at starting location
+  await page.getByRole('button', { name: /Claim/ }).click()
+  await page.locator('select').selectOption('2')
+  await page.getByRole('button', { name: /Confirm claim/i }).click()
+
+  // End turn with a rest
+  await page.getByRole('button', { name: /Rest/ }).click()
+  await page.getByRole('button', { name: /Rest/ }).click()
+  await expect(page.locator('text=AI Player')).toBeVisible()
+  await page.waitForTimeout(1000)
+
+  // Start of next round - claim 1 more to reach 3
+  await page.getByRole('button', { name: /Claim/ }).click()
+  await page.locator('select').selectOption('1')
+  await page.getByRole('button', { name: /Confirm claim/i }).click()
+
+  // Rest to end turn
+  await page.getByRole('button', { name: /Rest/ }).click()
+  await expect(page.locator('text=AI Player')).toBeVisible()
+  await page.waitForTimeout(1000)
+
+  const gemSaloon = getLocationCard(page, 'Gem Saloon')
+  const starText = await gemSaloon.locator('text=★★★').first().textContent()
+  expect(starText).toBe('★★★')
+})
+


### PR DESCRIPTION
## Summary
- test that influence stars remain after reaching three influence
- log update in docs

## Testing
- `npm run lint`
- `npm test` *(fails: 7 failed, 2 interrupted, 23 skipped, 19 passed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68617aad2f44832fa625adbc1a6d9942