### PR TITLE
Fix influence star persistence

### DIFF
--- a/docs/task-update.md
+++ b/docs/task-update.md
@@ -97,3 +97,19 @@
 
 - Created Playwright spec to ensure claim stars remain visible after reaching three influence
 - What's next: verify tests and build succeed
+
+### [2025-06-29 18:14 UTC] Add player color indicators
+
+- Added colored stars and border styling for current and other players
+- Introduced data-testid attributes for reliable selectors
+- Created Playwright test verifying star visibility
+- What's next: ensure lint, test and build pass
+
+### [2025-06-29 18:26 UTC] Fix influence star persistence
+
+- Updated `LocationCard` to reference all players when rendering influences so
+  stars remain visible after players move away
+- Passed `allPlayers` from `DeadwoodGame`
+- Added Playwright test covering influence persistence when moving to another
+  location
+- What's next: run full test suite and ensure build succeeds

--- a/src/DeadwoodGame.tsx
+++ b/src/DeadwoodGame.tsx
@@ -359,7 +359,9 @@ const DeadwoodGame: React.FC = () => {
             padding: '1rem',
             marginBottom: '1rem',
             boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
+            border: `3px solid ${currentPlayer?.color}`,
           }}
+          data-testid="current-player"
         >
           <div
             style={{
@@ -375,8 +377,17 @@ const DeadwoodGame: React.FC = () => {
                   fontWeight: 'bold',
                   fontSize: '1.1rem',
                   color: '#654321',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.25rem',
                 }}
               >
+                <span
+                  data-testid="current-player-star"
+                  style={{ color: currentPlayer?.color }}
+                >
+                  ★
+                </span>
                 {currentPlayer?.name} - {currentPlayer?.character.name}
               </div>
               <div
@@ -449,6 +460,7 @@ const DeadwoodGame: React.FC = () => {
                 key={location.id}
                 location={location}
                 players={playersAtLocation}
+                allPlayers={gameState.players}
                 onClick={() => handleLocationClick(location.id)}
                 isValidTarget={isValidTarget}
                 currentPlayerId={currentPlayer?.id || ''}
@@ -490,9 +502,25 @@ const DeadwoodGame: React.FC = () => {
                   padding: '0.5rem',
                   background: 'rgba(255, 255, 255, 0.5)',
                   borderRadius: '4px',
+                  border: `2px solid ${player.color}`,
                 }}
+                data-testid={`other-player-${player.id}`}
               >
-                <div style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>
+                <div
+                  style={{
+                    fontWeight: 'bold',
+                    marginBottom: '0.25rem',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.25rem',
+                  }}
+                >
+                  <span
+                    data-testid="player-star"
+                    style={{ color: player.color }}
+                  >
+                    ★
+                  </span>
                   {player.name} - {player.character.name}
                 </div>
                 <div

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -4,7 +4,10 @@ import styles from './LocationCard.module.css'
 
 interface Props {
   location: DWLocation
+  /** Players currently at this location */
   players: Player[]
+  /** All players in the game (for looking up influence colors) */
+  allPlayers: Player[]
   onClick: () => void
   isValidTarget: boolean
   currentPlayerId: string
@@ -16,6 +19,7 @@ interface Props {
 const LocationCard: React.FC<Props> = ({
   location,
   players,
+  allPlayers,
   onClick,
   isValidTarget,
   currentPlayerId,
@@ -41,7 +45,7 @@ const LocationCard: React.FC<Props> = ({
       {influences.length > 0 && (
         <div className={styles.influences}>
           {influences.map(([playerId, influence]) => {
-            const player = players.find((p) => p.id === playerId)
+            const player = allPlayers.find((p) => p.id === playerId)
             if (!player) return null
             return (
               <div

--- a/tests/influence_persistence.spec.ts
+++ b/tests/influence_persistence.spec.ts
@@ -42,3 +42,23 @@ test('influence stars persist after reaching three', async ({ page }) => {
   expect(starText).toBe('★★★')
 })
 
+test('influence stars remain after player moves away', async ({ page }) => {
+  await startGame(page)
+
+  await page.getByRole('button', { name: /Claim/ }).click()
+  await page.locator('select').selectOption('1')
+  await page.getByRole('button', { name: /Confirm claim/i }).click()
+
+  // Move to a different location and end turn
+  await page.getByRole('button', { name: /Move/ }).click()
+  await page.getByRole('heading', { name: 'Hardware Store' }).click()
+  await page.getByRole('button', { name: /Confirm move/i }).click()
+  await page.getByRole('button', { name: /Rest/ }).click()
+  await expect(page.locator('text=AI Player')).toBeVisible()
+  await page.waitForTimeout(1000)
+
+  const gemSaloon = getLocationCard(page, 'Gem Saloon')
+  const star = gemSaloon.locator('text=★')
+  await expect(star).toBeVisible()
+})
+

--- a/tests/player_color_ui.spec.ts
+++ b/tests/player_color_ui.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test'
+
+async function startGame(page) {
+  await page.goto('/')
+  await page.getByRole('button', { name: 'Start Game' }).click()
+  await expect(page.locator('text=Round 1 \u2022')).toBeVisible()
+}
+
+test('displays colored stars for each player', async ({ page }) => {
+  await startGame(page)
+
+  const currentStar = page.getByTestId('current-player-star')
+  await expect(currentStar).toBeVisible()
+
+  const others = page.getByTestId(/other-player-/)
+  await expect(others.first().getByTestId('player-star')).toBeVisible()
+})


### PR DESCRIPTION
## Summary
- allow `LocationCard` to access all players for star rendering
- ensure influence stars stay visible after players move away
- test influence persistence when moving to a new location
- document progress in the task update log

## Testing
- `npm ci`
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686181965388832fbd6a2732c9368400