### PR TITLE
Fix influence star color bug

### DIFF
--- a/docs/task-update.md
+++ b/docs/task-update.md
@@ -113,3 +113,8 @@
 - Added Playwright test covering influence persistence when moving to another
   location
 - What's next: run full test suite and ensure build succeeds
+
+### [2025-06-30 12:02 UTC] Fix player color display bug
+- Removed conditional influence star styling overriding player colors
+- Verified lint, tests, and build all succeed
+- What's next: monitor UI to ensure colors remain consistent

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -53,8 +53,7 @@ const LocationCard: React.FC<Props> = ({
                 className={styles.influence}
                 data-current={playerId === currentPlayerId}
                 style={{
-                  color:
-                    playerId === currentPlayerId ? '#006400' : player.color,
+                  color: player.color,
                 }}
               >
                 {'★'.repeat(influence)}


### PR DESCRIPTION
## Summary
- always render influence stars with the player's assigned color
- log progress in docs/task-update

## Testing
- `npm ci`
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68627bd242a8832f9e3dbc24c435ca4f